### PR TITLE
Fix for Point Sum taking into account hidden cards

### DIFF
--- a/trelloscrum.js
+++ b/trelloscrum.js
@@ -126,7 +126,7 @@ function listCard(e){
 
 	this.__defineGetter__('points',function(){
 		//don't add to total when filtered out
-		return parsed&&(!filtered||$card.css('opacity')==1)?points:''
+		return parsed&&(filtered && ($card.css('opacity')<1 || $card.css('display')=='none'))?"":points
 	});
 
 	getPoints()


### PR DESCRIPTION
Here is a patch for the list total to filter out hidden cards.  This is to keep up with Trello, as they added the ability to either filter cards with a transparency or completely hidden. 
