### PR TITLE
Hover title in singular or plural form, depending on number of points.

### DIFF
--- a/trelloscrum.js
+++ b/trelloscrum.js
@@ -95,7 +95,7 @@ function listCard(e){
 		$title.html($title.html().replace(reg,''));
 		if($card.parent()[0]){
 			$badge.text(that.points).prependTo($card.find('.badges'));
-			$badge.attr({title: 'This card has '+that.points+' storypoint(s).'})
+			$badge.attr({title: 'This card has '+that.points+' storypoint' + (that.points == 1 ? '.' : 's.')})
 		}
 		busy=false;
 		calcPoints($card.closest('.list'))


### PR DESCRIPTION
Just a minor tweak that fixes a pet peeve of mine. When you hover over a card points icon the text in the title will now be pluralized properly (instead of lazily).
