### PR TITLE
Support for Safari

### DIFF
--- a/trelloscrum.js
+++ b/trelloscrum.js
@@ -21,7 +21,7 @@ var _pointSeq = ['?', 0, 1, 2, 3, 5, 8, 13, 20];
 //internals
 var filtered = false, //watch for filtered cards
 	reg = /\((\x3f|\d*\.?\d+)\)\s?/m, //parse regexp- accepts digits, decimals and '?'
-	iconUrl = chrome.extension.getURL('images/storypoints-icon.png');
+	iconUrl = $.browser.safari == true?(safari.extension.baseURI + 'images/storypoints-icon.png'):(chrome.extension.getURL('images/storypoints-icon.png'));
 
 //what to do when DOM loads
 $(function(){


### PR DESCRIPTION
I've been using TrelloScrum for a while on Chrome. Ever since I moved to the new MBP with Retina I had to move to Safari since Chrome wasn't rendering web content so well. One of the first browser plugins I started missing was TrelloScrum.

Since Chrome and Safari share Webkit I attempted to port TrelloScrum to Safari and came up with a very simple code change which makes this source now work with Safari as well.

I hope this change can help support TrelloScrum on Safari as well.
