### PR TITLE
Make points total update when filters are changed with the new filter UI

### DIFF
--- a/trelloscrum.js
+++ b/trelloscrum.js
@@ -41,12 +41,15 @@ var Utils = (function(){
 //what to do when DOM loads
 $(function(){
 	//watch filtering
-	$('.js-filter-toggle').live('mouseup',function(e){
+	function updateFilters() {
 		setTimeout(function(){
 			filtered=$('.js-filter-cards').hasClass('is-on');
 			calcPoints()
-		})
-	});
+		})		
+	}
+	$('.js-toggle-label-filter, .js-select-member, .js-due-filter, .js-clear-all').live('mouseup', updateFilters);
+	$('.js-input').live('keyup', updateFilters);
+	
 
 	//for storypoint picker
 	$(".card-detail-title .edit-controls").live('DOMNodeInserted',showPointPicker);


### PR DESCRIPTION
Updating points after filters are changed was broken since the [new filters UI](https://trello.com/card/updated-card-filter-including-filter-by-due-date-in-board-view/4d5ea62fd76aa1136000000c/1374), see #28
