### PR TITLE
Fixed broken totals issue

### DIFF
--- a/trelloscrum.js
+++ b/trelloscrum.js
@@ -124,7 +124,7 @@ function List(el){
 	$list.bind('DOMNodeInserted',function(e){
 		if($(e.target).hasClass('list-card') && !e.target.listCard) {
 			clearTimeout(to2);
-			to2=setTimeout(readCard,0,$(e.target))
+			to2=setTimeout(function(){readCard($(e.target))})
 		}
 	});
 


### PR DESCRIPTION
Wrapped `readCard` in an anonymopus function and passed `$(e.target)` as a parameter.

Fixes https://github.com/Q42/TrelloScrum/issues/38
