### PR TITLE
Change list total to absolute positioning

### DIFF
--- a/trelloscrum.css
+++ b/trelloscrum.css
@@ -1,4 +1,7 @@
 .list-total {
+	position: absolute;
+	right: 32px;
+	top: 6px;
 	color: #006580;
 	font-size: 16px;
 	font-weight: bold;


### PR DESCRIPTION
Since Trello added the ellipsis button to the right, the list total was breaking to the second line. This makes it absolute positioned and hence fixes the issue – I hope :)

It fixes #97 

The updated build looks like this:
<img width="282" alt="screen shot 2016-04-11 at 9 59 04 pm" src="https://cloud.githubusercontent.com/assets/274971/14446974/eb3c70ee-0031-11e6-807b-09e665c32d9f.png">

I went with the absolute positioning because:
1. It will be less likely to break something they introduce. The alternate approach would be to change the .list-header to a flex container, which means messing with Trello's CSS – I guess it's not something I should be doing unless necessary.
2. The ellipsis button is already using absolute positioning, so why not?
3. Changing to a flex container would break the card count, this does not.

I hope this helps 👍 