### PR TITLE
Use window.URL instead of window.webkitURL

### DIFF
--- a/trelloscrum.js
+++ b/trelloscrum.js
@@ -770,7 +770,6 @@ function showPointPicker(location) {
 
 //for export
 var $excel_btn,$excel_dl;
-window.URL = window.webkitURL || window.URL;
 
 function checkExport() {
 	if($excel_btn && $excel_btn.filter(':visible').length) return;


### PR DESCRIPTION
It seems like window.webkitURL is deprecated on latest chrome.

```
chrome-extension://jdbcdblgjdpmfninkoogcfpnkjmndgje/trelloscrum.js:773 'webkitURL' is deprecated. Please use 'URL' instead.
(anonymous)	@	chrome-extension://jdbcdblgjdpmfninkoogcfpnkjmndgje/trelloscrum.js:773
```

Therefore it leads to huge performance loss for my trello and I've fixed it.​